### PR TITLE
Build linux/arm64 image

### DIFF
--- a/.github/workflows/docker-publish-fork.yml
+++ b/.github/workflows/docker-publish-fork.yml
@@ -48,6 +48,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ github.ref_name }}


### PR DESCRIPTION
We run claude-code-action on arm64 self-hosted runners. I noticed that this image does not support arm64. Could you please add it?

Thank you for the great action!